### PR TITLE
Feature: email with report is getting sent if pass rate is lower than specified threshold

### DIFF
--- a/src/com/zebrunner/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
+++ b/src/com/zebrunner/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
@@ -177,6 +177,8 @@ public class TestJobFactory extends PipelineFactory {
                 }
                 stringParam('email_list', getSuiteParameter("", "jenkinsEmail", currentSuite), 'List of Users to be emailed after the test')
                 configure addHiddenParameter('failure_email_list', '', getSuiteParameter("", "jenkinsFailedEmail", currentSuite))
+                configure addHiddenParameter('threshold_email_list', '', getSuiteParameter("", "jenkinsThresholdEmail", currentSuite))
+                configure addHiddenParameter('threshold_email_percent', '', getSuiteParameter("", "jenkinsThresholdEmailPercent", currentSuite))
                 choiceParam('retry_count', getRetryCountArray(currentSuite), 'Number of Times to Retry a Failed Test')
                 booleanParam('rerun_failures', false, 'During \"Rebuild\" pick it to execute only failed cases')
                 configure addHiddenParameter('overrideFields', '', getSuiteParameter("", "overrideFields", currentSuite))

--- a/src/com/zebrunner/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
+++ b/src/com/zebrunner/jenkins/jobdsl/factory/pipeline/TestJobFactory.groovy
@@ -177,8 +177,7 @@ public class TestJobFactory extends PipelineFactory {
                 }
                 stringParam('email_list', getSuiteParameter("", "jenkinsEmail", currentSuite), 'List of Users to be emailed after the test')
                 configure addHiddenParameter('failure_email_list', '', getSuiteParameter("", "jenkinsFailedEmail", currentSuite))
-                configure addHiddenParameter('threshold_email_list', '', getSuiteParameter("", "jenkinsThresholdEmail", currentSuite))
-                configure addHiddenParameter('threshold_email_percent', '', getSuiteParameter("", "jenkinsThresholdEmailPercent", currentSuite))
+                configure addHiddenParameter('failure_email_pass_rate_threshold', '', getSuiteParameter("", "jenkinsFailedEmailPassRateThreshold", currentSuite))
                 choiceParam('retry_count', getRetryCountArray(currentSuite), 'Number of Times to Retry a Failed Test')
                 booleanParam('rerun_failures', false, 'During \"Rebuild\" pick it to execute only failed cases')
                 configure addHiddenParameter('overrideFields', '', getSuiteParameter("", "overrideFields", currentSuite))

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraClient.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraClient.groovy
@@ -185,6 +185,19 @@ class ZafiraClient extends HttpClient {
         return sendRequestFormatted(parameters)
     }
 
+    public def getTestRunResults(testRunId) {
+        if (!isZafiraConnected()) {
+            return
+        }
+        def parameters = [customHeaders     : [[name: 'Authorization', value: "${authToken}"]],
+                          contentType       : 'APPLICATION_JSON',
+                          httpMode          : 'GET',
+                          validResponseCodes: "200:404",
+                          url               : this.serviceURL + "/api/reporting/api/tests/runs/${testRunId}/results"]
+
+        return sendRequestFormatted(parameters)
+    }
+
 
     public def createLaunchers(jenkinsJobsScanResult) {
         if (!isZafiraConnected()) {

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -123,8 +123,8 @@ class ZafiraUpdater {
         }
 
         String thresholdEmailList = Configuration.get("threshold_email_list")
-        double thresholdEmailPercent = Configuration.get("threshold_email_percent")
         if (isFailure(testRun.status) && !isParamEmpty(thresholdEmailList)) {
+            def thresholdEmailPercent = Configuration.get("threshold_email_percent")
             def testRunResults = zc.getTestRunResults(testRun.id)
             int overallCount = 0
             int failedCount = 0

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -136,7 +136,7 @@ class ZafiraUpdater {
             }
             logger.info("Overall tests count: " + overallCount)
             logger.info("Failed tests count: " + failedCount)
-            def successRate = (overallCount - failedCount / overallCount) * 100
+            def successRate = ((overallCount - failedCount) / overallCount) * 100
             logger.info("Success rate(%): " + successRate)
             if (successRate < thresholdEmailPercent) {
                 logger.info("Sending email as success rate is less then threshold: ")

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -136,12 +136,12 @@ class ZafiraUpdater {
                 logger.info("Success rate(%): " + successRate)
                 if (successRate < thresholdEmailPercent) {
                     logger.info("Sending failure email as success rate is less then pass rate threshold")
-                    zc.sendEmail(uuid, failureEmailList, "all")
+                    zc.sendEmail(uuid, failureEmailList.minus(emailList), "all")
                 } else {
                     logger.info("Not sending failure email as success rate is greater then pass rate threshold")
                 }
             } else {
-                zc.sendEmail(uuid, failureEmailList, "all")
+                zc.sendEmail(uuid, failureEmailList.minus(emailList), "all")
             }
         }
     }

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -124,7 +124,7 @@ class ZafiraUpdater {
 
         String thresholdEmailList = Configuration.get("threshold_email_list")
         if (isFailure(testRun.status) && !isParamEmpty(thresholdEmailList)) {
-            def thresholdEmailPercent = Configuration.get("threshold_email_percent")
+            double thresholdEmailPercent = Configuration.get("threshold_email_percent") as Double
             def testRunResults = zc.getTestRunResults(testRun.id)
             int overallCount = 0
             int failedCount = 0
@@ -136,8 +136,8 @@ class ZafiraUpdater {
             }
             logger.info("Overall tests count: " + overallCount)
             logger.info("Failed tests count: " + failedCount)
-            def successRate = failedCount / overallCount
-            logger.info("Success rate: " + successRate)
+            def successRate = (overallCount - failedCount / overallCount) * 100
+            logger.info("Success rate(%): " + successRate)
             if (successRate < thresholdEmailPercent) {
                 logger.info("Sending email as success rate is less then threshold: ")
                 zc.sendEmail(uuid, thresholdEmailList, "all")

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -139,8 +139,8 @@ class ZafiraUpdater {
             def successRate = ((overallCount - failedCount) / overallCount) * 100
             logger.info("Success rate(%): " + successRate)
             if (successRate < thresholdEmailPercent) {
-                logger.info("Sending email as success rate is less then threshold: ")
-                zc.sendEmail(uuid, thresholdEmailList, "all")
+                logger.info("Sending email as success rate is less then threshold")
+                zc.sendEmail(uuid, thresholdEmailList.minus(emailList), "all")
             }
         }
     }

--- a/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
+++ b/src/com/zebrunner/jenkins/pipeline/integration/zafira/ZafiraUpdater.groovy
@@ -119,28 +119,29 @@ class ZafiraUpdater {
         }
         String failureEmailList = Configuration.get("failure_email_list")
         if (isFailure(testRun.status) && !isParamEmpty(failureEmailList)) {
-            zc.sendEmail(uuid, failureEmailList, "failures")
-        }
-
-        String thresholdEmailList = Configuration.get("threshold_email_list")
-        if (isFailure(testRun.status) && !isParamEmpty(thresholdEmailList)) {
-            double thresholdEmailPercent = Configuration.get("threshold_email_percent") as Double
-            def testRunResults = zc.getTestRunResults(testRun.id)
-            int overallCount = 0
-            int failedCount = 0
-            testRunResults.each { trr ->
-                if (isFailure(trr.status) && !trr.knownIssue) {
-                    failedCount ++
+            if (!isParamEmpty(Configuration.get("failure_email_pass_rate_threshold"))) {
+                double thresholdEmailPercent = Configuration.get("failure_email_pass_rate_threshold") as Double
+                def testRunResults = zc.getTestRunResults(testRun.id)
+                int overallCount = 0
+                int failedCount = 0
+                testRunResults.each { trr ->
+                    if (isFailure(trr.status) && !trr.knownIssue) {
+                        failedCount ++
+                    }
+                    overallCount ++
                 }
-                overallCount ++
-            }
-            logger.info("Overall tests count: " + overallCount)
-            logger.info("Failed tests count: " + failedCount)
-            def successRate = ((overallCount - failedCount) / overallCount) * 100
-            logger.info("Success rate(%): " + successRate)
-            if (successRate < thresholdEmailPercent) {
-                logger.info("Sending email as success rate is less then threshold")
-                zc.sendEmail(uuid, thresholdEmailList.minus(emailList), "all")
+                logger.info("Overall tests count: " + overallCount)
+                logger.info("Failed tests count: " + failedCount)
+                def successRate = ((overallCount - failedCount) / overallCount) * 100
+                logger.info("Success rate(%): " + successRate)
+                if (successRate < thresholdEmailPercent) {
+                    logger.info("Sending failure email as success rate is less then pass rate threshold")
+                    zc.sendEmail(uuid, failureEmailList, "all")
+                } else {
+                    logger.info("Not sending failure email as success rate is greater then pass rate threshold")
+                }
+            } else {
+                zc.sendEmail(uuid, failureEmailList, "all")
             }
         }
     }


### PR DESCRIPTION
2 new suite parameters were introduced:
jenkinsThresholdEmail
jenkinsThresholdEmailPercent

In case if run pass rate is lower than threshold specified in `jenkinsThresholdEmailPercent` then email will be sent to addresses mentioned in `jenkinsThresholdEmail`
In case if emails from `jenkinsThresholdEmail` are duplicated in regular `jenkinsEmail` then report won't be sent twice
